### PR TITLE
Enable LLM-first QA agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 | `codex map [plan.yaml]`              | Generate codebase map (docs/map)    | `codex map`                         |
-| `codex ask [--no-fallback] <query>`  | QA over code map (heuristic + LLM)  | `codex ask "Where is Foo?"`       |
+| `codex ask [--no-fallback] <query>`  | QA over code map (LLM + heuristic fallback)  | `codex ask "Where is Foo?"`       |
 <h1 align="center">OpenAI Codex CLI</h1>
 <p align="center">Lightweight coding agent that runs in your terminal</p>
 

--- a/agents/qa-agent.yaml
+++ b/agents/qa-agent.yaml
@@ -1,0 +1,8 @@
+name: qa-agent
+role: "QA agent over code map"
+enabled: true
+model:
+  provider: openai
+  id: o4-mini
+cost_budget_usd: 0.20
+allowed_syscalls: ["shell"]

--- a/docs/commands/ask.md
+++ b/docs/commands/ask.md
@@ -8,9 +8,8 @@ codex ask [--no-fallback] "your question"
 **Description:**
 Answers natural-language questions about your repository's code map.
 
-1. Performs a fast local heuristic lookup (symbols, modules, tasks).
-2. If no answer found and fallback is enabled, sends your question along with a brief
-   map summary to an LLM (default `gpt-4.1-mini`).
+1. Sends your question with a brief map summary to an LLM (default `gpt-4.1-mini`).
+2. If the LLM is disabled or fails, falls back to a fast local heuristic lookup (symbols, modules, tasks).
 
 **Options:**
 - `--no-fallback`  Skip the LLM step and only use heuristics.


### PR DESCRIPTION
## Summary
- default `askCommand` to use the LLM first and fall back to heuristics
- use the new behaviour from the CLI
- document updated behaviour
- add `qa-agent` worker definition

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND, eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686586cbd3e88322b8c4158e0ad34bce
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The `ask` command now uses the LLM first to answer questions, and falls back to heuristics if needed. Added a `qa-agent` worker definition and updated documentation to match the new behavior.

- **New Features**
  - Added `agents/qa-agent.yaml` for the QA agent worker.
  - Updated CLI and docs to reflect LLM-first approach for code map questions.

<!-- End of auto-generated description by cubic. -->

